### PR TITLE
Use consistent identifier for USENIX Security.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Automatic test generation typically aims to generate inputs that explore new pat
 </details>
 
 --------------------------------------------------------------------------------------------------------------------------
-### [SEC'20] FuzzGuard: Filtering out Unreachable Inputs in Directed Grey-box Fuzzing through Deep Learning 
+### [Usenix'20] FuzzGuard: Filtering out Unreachable Inputs in Directed Grey-box Fuzzing through Deep Learning 
 
 [[paper]](http://kaichen.org/paper/conference/sec20summer-final343.pdf) [[project]](https://github.com/zongpy/FuzzGuard) [[slides]](https://www.usenix.org/system/files/sec20_slides_zong.pdf) [[talk]](https://www.usenix.org/conference/usenixsecurity20/presentation/zong)
 
@@ -113,7 +113,7 @@ with the state-of-the-art DGF (e.g., AFLGo). Evaluations on 45 real vulnerabilit
 </details>
 
 --------------------------------------------------------------------------------------------------------------------------
-### [SEC'20] ParmeSan: Sanitizer-guided Greybox Fuzzing 
+### [Usenix'20] ParmeSan: Sanitizer-guided Greybox Fuzzing 
 
 [[paper]](https://download.vusec.net/papers/parmesan_sec20.pdf) [[project]](https://github.com/vusec/parmesan) [[slides]](https://www.usenix.org/system/files/sec20_slides_osterlund.pdf) [[talk]](https://www.usenix.org/conference/usenixsecurity20/presentation/osterlund)
 


### PR DESCRIPTION
Just thought this would be convenient since the curated list is quite long now.